### PR TITLE
Add about overflow-x to the visible value

### DIFF
--- a/files/zh-cn/web/css/overflow-y/index.html
+++ b/files/zh-cn/web/css/overflow-y/index.html
@@ -40,7 +40,7 @@ overflow-y: unset; /*未设置*/
 
 <dl>
  <dt><code>visible</code></dt>
- <dd>内容不会被截断，且可以显示在内容盒之外。</dd>
+ <dd>内容不会被截断，且可以显示在内容盒之外。当 <code><a href="/en-US/docs/Web/CSS/overflow-x">overflow-x</a></code> 值为 <code>hidden</code>、<code>scroll</code> 或者 <code>auto</code>，而本属性的值为 <code>visible</code> 时，本属性会被隐式的计算为 <code>auto</code>。</dd>
  <dt><code>hidden</code></dt>
  <dd>内容会被截断，且不会显示滚动条。</dd>
 </dl>


### PR DESCRIPTION
According to the English version, when the value is visible, overflow-x and overflow-y are related. But that is not mentioned in the zh-cn version